### PR TITLE
Simplify hdf5/netcdf bundling

### DIFF
--- a/gdal-src/Cargo.toml
+++ b/gdal-src/Cargo.toml
@@ -10,9 +10,8 @@ links = "gdal_src"
 link-cplusplus = "1.0"
 proj-sys = { version = "0.24.0", features = ["bundled_proj"] }
 libsqlite3-sys = { version = "0.28.0", features = ["bundled"], optional = true }
-hdf5-src = { version = "0.8.1", optional = true, features = ["hl"] }
-hdf5-sys = { version = "0.8.1", optional = true, features = ["static"] }
-netcdf-src = { version = "0.3.3", optional = true }
+hdf5-sys = { package = "hdf5-metno-sys", version = "0.9.1", optional = true, features = ["static", "hl", "deprecated"] }
+netcdf-sys = { version = "0.8.1", optional = true, features = ["static"] }
 pq-src = { version = "0.1.3", optional = true }
 curl-sys = { version = "0.4.70", features = ["static-curl"], optional = true }
 libz-sys = { version = "1.1.15", features = ["static"], optional = true }
@@ -56,11 +55,11 @@ all_drivers = [
 # that you statically link libgeos and
 # therefore makes your binary fall under
 # LGPL as well
-geos_static = ["geos", "geos-sys/static", "geos-src"]
+geos_static = ["geos", "dep:geos-sys", "geos-sys?/static", "dep:geos-src"]
 # as long as the `geos_static` feature
 # is not enabled that will only
 # dynamically link geos
-geos = ["geos-sys"]
+geos = ["dep:geos-sys"]
 
 internal_drivers = [
     # ogr internal,
@@ -275,6 +274,7 @@ driver_vfk = ["driver_sqlite"]
 driver_rasterlite = [] # unclear how to handle that
 
 # curl
+curl-sys = ["dep:curl-sys"]
 driver_amigocloud = ["curl-sys"]
 driver_carto = ["curl-sys"]
 driver_daas = ["curl-sys"]
@@ -310,10 +310,10 @@ driver_pg = ["dep:pq-src"]
 driver_postgis_raster = ["driver_pg"]
 
 # libhdf5
-driver_hdf5 = ["dep:hdf5-src", "dep:libz-sys"]
+driver_hdf5 = ["dep:hdf5-sys", "hdf5-sys?/zlib", "dep:libz-sys"]
 
 # libnetcdf
-driver_netcdf = ["dep:netcdf-src", "driver_hdf5", "dep:hdf5-sys"]
+driver_netcdf = ["dep:netcdf-sys", "driver_hdf5"]
 
 # poppler
 #driver_pdf = []

--- a/gdal-src/Cargo.toml
+++ b/gdal-src/Cargo.toml
@@ -274,7 +274,6 @@ driver_vfk = ["driver_sqlite"]
 driver_rasterlite = [] # unclear how to handle that
 
 # curl
-curl-sys = ["dep:curl-sys"]
 driver_amigocloud = ["curl-sys"]
 driver_carto = ["curl-sys"]
 driver_daas = ["curl-sys"]

--- a/gdal-src/build.rs
+++ b/gdal-src/build.rs
@@ -215,7 +215,6 @@ fn main() {
 
     if cfg!(feature = "driver_hdf5") {
         let hdf5_dir = std::env::var("DEP_HDF5_ROOT").expect("This is set by hdf5-sys");
-        // let hdf5_dir = format!("{hdf5_dir}/..");
         let hdf5_lib = std::env::var("DEP_HDF5_LIBRARY").expect("This is set by hdf5-sys");
         let hdf5_lib_dir = find_library(&hdf5_lib, &hdf5_dir);
         let mut hdf5_cc = PathBuf::from(&hdf5_dir);

--- a/gdal-src/build.rs
+++ b/gdal-src/build.rs
@@ -214,18 +214,15 @@ fn main() {
     handle_ogr_driver!(config, "driver_vfk");
 
     if cfg!(feature = "driver_hdf5") {
-        let hdf5_dir = std::env::var("DEP_HDF5SRC_ROOT").expect("This is set by hdf5-src");
-        let hdf5_lib = std::env::var("DEP_HDF5SRC_LIBRARY").expect("This is set by hdf5-src");
+        let hdf5_dir = std::env::var("DEP_HDF5_ROOT").expect("This is set by hdf5-sys");
+        // let hdf5_dir = format!("{hdf5_dir}/..");
+        let hdf5_lib = std::env::var("DEP_HDF5_LIBRARY").expect("This is set by hdf5-sys");
         let hdf5_lib_dir = find_library(&hdf5_lib, &hdf5_dir);
-        let p = PathBuf::from(&hdf5_lib_dir);
         let mut hdf5_cc = PathBuf::from(&hdf5_dir);
         hdf5_cc.push("bin");
         hdf5_cc.push("h5cc");
-        let mut hdf5_include = PathBuf::from(&hdf5_dir);
-        hdf5_include.push("include");
-        let p = p.parent().unwrap();
-        println!("cargo:rustc-link-search=native={}", p.display());
-        println!("cargo:rustc-link-lib=static={hdf5_lib}");
+        let hdf5_include = std::env::var("DEP_HDF5_INCLUDE").expect("This is set by hdf5-sys");
+        let hdf5_include = PathBuf::from(&hdf5_include);
         config
             .define("GDAL_USE_HDF5", "ON")
             .define("HDF5_C_COMPILER_EXECUTABLE", print_path(&hdf5_cc))
@@ -239,28 +236,14 @@ fn main() {
     }
 
     if cfg!(feature = "driver_netcdf") {
-        let netcdf_root_dir =
-            std::env::var("DEP_NETCDFSRC_ROOT").expect("This is set by netcdf-src");
-        let hdf5_dir = std::env::var("DEP_HDF5SRC_ROOT").expect("This is set by hdf5-src");
-        let hl_library = std::env::var("DEP_HDF5SRC_HL_LIBRARY").expect("This is set by hdf5-src");
-        let netcdf_lib = find_library("netcdf", &netcdf_root_dir);
-        let hl_library_path = find_library(&hl_library, hdf5_dir);
-        let hl_library_path = hl_library_path.parent().unwrap();
+        let netcdf_include =
+            std::env::var("DEP_NETCDF_INCLUDEDIR").expect("This is set by netcdf-sys");
+        let netcdf_root = format!("{netcdf_include}/..");
 
-        let netcdf_library_path = netcdf_lib.parent().unwrap();
-        println!(
-            "cargo:rustc-link-search=native={}",
-            netcdf_library_path.display()
-        );
-        println!("cargo:rustc-link-lib=static=netcdf");
-        println!(
-            "cargo:rustc-link-search=native={}",
-            hl_library_path.display()
-        );
-        println!("cargo:rustc-link-lib=static={hl_library}");
+        let netcdf_include = PathBuf::from(netcdf_include);
+        let netcdf_root = PathBuf::from(netcdf_root);
+        let netcdf_lib = find_library("netcdf", &netcdf_root);
 
-        let mut netcdf_include = PathBuf::from(netcdf_root_dir);
-        netcdf_include.push("include");
         config
             .define("GDAL_USE_NETCDF", "ON")
             .define("NETCDF_INCLUDE_DIR", print_path(&netcdf_include))

--- a/gdal-src/src/lib.rs
+++ b/gdal-src/src/lib.rs
@@ -3,11 +3,11 @@ extern crate curl_sys;
 #[cfg(feature = "geos")]
 extern crate geos_sys;
 #[cfg(feature = "driver_hdf5")]
-extern crate hdf5_src;
+extern crate hdf5_sys;
 #[cfg(feature = "driver_sqlite")]
 extern crate libsqlite3_sys;
 #[cfg(feature = "driver_netcdf")]
-extern crate netcdf_src;
+extern crate netcdf_sys;
 #[cfg(feature = "driver_pg")]
 extern crate pq_src;
 


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
The `*-sys` crates deals with linking, so it is only necessary to use the `*-sys` crates.

Updates both `hdf5` and `netCDF` with the latest versions. `hdf5` is using a more updated fork

@weiznich 